### PR TITLE
windows terminal theme base on minimal kiwi

### DIFF
--- a/extras/windows-terminal.json
+++ b/extras/windows-terminal.json
@@ -1,0 +1,26 @@
+{
+"schemes":[
+    {
+      "name": "Minimal Kiwi",
+      "background": "#1E1E1E",
+      "foreground": "#D4D4D4",
+      "cursorColor": "#00FF99",
+      "black": "#000000",
+      "red": "#FF5F5F",
+      "green": "#00FF99",
+      "yellow": "#FFFF87",
+      "blue": "#5FAFFF",
+      "purple": "#AF87FF",
+      "cyan": "#5FFFFF",
+      "white": "#FFFFFF",
+      "brightBlack": "#808080",
+      "brightRed": "#FF8787",
+      "brightGreen": "#87FFAF",
+      "brightYellow": "#FFFFAF",
+      "brightBlue": "#87D7FF",
+      "brightPurple": "#D7AFFF",
+      "brightCyan": "#87FFFF",
+      "brightWhite": "#E4E4E4"
+    }
+  ]
+}


### PR DESCRIPTION
create a JSON file for windows terminal theme based on Minimal Kiwi
I set it into extras folder but if you think about better way tell me thank you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows Terminal color scheme, “Minimal Kiwi,” with a dark background (#1E1E1E), light foreground (#D4D4D4), and a kiwi-green cursor (#00FF99).
  * Includes a complete 16-color palette (standard and bright variants) for consistent theming across prompts and applications.
  * Users can import the scheme via Windows Terminal settings to quickly apply the look across profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->